### PR TITLE
Analyzer for GL.Begin and GL.End comformity.

### DIFF
--- a/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTKAnalyzer.Test.csproj
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTKAnalyzer.Test.csproj
@@ -106,6 +106,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OpenTK_\Graphics_\OpenGL_\BeginEndAnalyzerTests.cs" />
     <Compile Include="TestHelper\CodeFixVerifier.cs" />
     <Compile Include="TestHelper\DiagnosticResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -124,6 +125,9 @@
   <ItemGroup>
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzerTests.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzerTests.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTKAnalyzer.TestHelper;
+
+namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_.Tests
+{
+	[TestClass]
+	public class BeginEndAnalyzerTests : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer CSharpDiagnosticAnalyzer => new BeginEndAnalyzer();
+
+		[TestMethod]
+		public void EmptyCode()
+		{
+			var test0Source = @"";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void NormalScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+class Class1
+{
+	void Method1()
+	{
+		GL.Begin(BeginMode.LineLoop);
+		GL.End();
+	}
+	void Method2()
+	{
+		GL.Begin(PrimitiveType.Triangles);
+		GL.End();
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void IncorrectScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+class Class1
+{
+	void Method1()
+	{
+		GL.Begin(BeginMode.LineLoop);
+	}
+	void Method2()
+	{
+		GL.End();
+	}
+	void Method3()
+	{
+		GL.Begin(PrimitiveType.TrianglesAdjacency);
+		GL.Begin(BeginMode.Patches);
+		GL.End();
+		GL.End();
+		GL.End();
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source,
+				new DiagnosticResult()
+				{
+					Id = BeginEndAnalyzer.DiagnosticId,
+					Message = "Missing GL.End.",
+					Severity = DiagnosticSeverity.Warning,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 3) }
+				},
+				new DiagnosticResult()
+				{
+					Id = BeginEndAnalyzer.DiagnosticId,
+					Message = "Missing GL.Begin.",
+					Severity = DiagnosticSeverity.Warning,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 3) }
+				},
+				new DiagnosticResult()
+				{
+					Id = BeginEndAnalyzer.DiagnosticId,
+					Message = "Missing GL.End.",
+					Severity = DiagnosticSeverity.Warning,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 3) }
+				},
+				new DiagnosticResult()
+				{
+					Id = BeginEndAnalyzer.DiagnosticId,
+					Message = "Missing GL.Begin.",
+					Severity = DiagnosticSeverity.Warning,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 3) }
+				},
+				new DiagnosticResult()
+				{
+					Id = BeginEndAnalyzer.DiagnosticId,
+					Message = "Missing GL.Begin.",
+					Severity = DiagnosticSeverity.Warning,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 18, 3) }
+				});
+		}
+	}
+}

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK/Graphics/OpenGL/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK/Graphics/OpenGL/BeginEndAnalyzer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	class BeginEndAnalyzer : DiagnosticAnalyzer
+	{
+		public const string DiagnosticId = "BeginEnd";
+
+		private const string Title = "GL.Begin and GL.End";
+		private const string MessageFormat = "{0} is missing.";
+		private const string Description = "";
+		private const string Category = "OpenTKAnalyzer:OpenGL";
+
+		internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: DiagnosticId,
+			title: Title,
+			messageFormat: MessageFormat,
+			category: Category,
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterCodeBlockAction(Analyze);
+		}
+
+		private static void Analyze(CodeBlockAnalysisContext context)
+		{
+			// TODO: syntax walker with block
+		}
+	}
+}

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
@@ -32,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="OpenTK\Graphics\OpenGL\BeginEndAnalyzer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="OpenTK\Graphics\OpenGL\BeginEndAnalyzer.cs" />
+    <Compile Include="OpenTK_\Graphics_\OpenGL_\BeginEndAnalyzer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -71,6 +71,7 @@
       <HintPath>..\..\packages\OpenTK.1.1.1589.5942\lib\NET40\OpenTK.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
@@ -5,8 +5,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using OpenTK.Graphics.OpenGL;
 
-namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
+namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	class BeginEndAnalyzer : DiagnosticAnalyzer
@@ -16,7 +17,7 @@ namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
 		private const string Title = "GL.Begin and GL.End comformity";
 		private const string MessageFormat = "Missing {0}.";
 		private const string Description = "";
-		private const string Category = "OpenTKAnalyzer:OpenGL";
+		private const string Category = nameof(OpenTKAnalyzer) + ":" + nameof(OpenTK.Graphics.OpenGL);
 
 		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
 			id: DiagnosticId,
@@ -38,7 +39,7 @@ namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
 		{
 			// filtering
 			if (context.CodeBlock.Ancestors().OfType<UsingDirectiveSyntax>()
-				.Where(u => u.Name.NormalizeWhitespace().ToFullString() == "OpenTK.Graphics.OpenGL").Any())
+				.Where(u => u.Name.NormalizeWhitespace().ToFullString() == nameof(OpenTK) + "." + nameof(OpenTK.Graphics) + "." + nameof(OpenTK.Graphics.OpenGL)).Any())
 			{
 				return;
 			}
@@ -61,7 +62,7 @@ namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
 				var statements = node.ChildNodes().OfType<ExpressionStatementSyntax>();
 				var invocations = statements.Select(s => s.Expression).OfType<InvocationExpressionSyntax>();
 				var glOperators = invocations.Select(i => i.Expression).OfType<MemberAccessExpressionSyntax>()
-					.Where(m => m.IsKind(SyntaxKind.SimpleMemberAccessExpression)).Where(s => s.GetFirstToken().Text == "GL");
+					.Where(m => m.IsKind(SyntaxKind.SimpleMemberAccessExpression)).Where(s => s.GetFirstToken().Text == nameof(GL));
 
 				// filtering
 				if (!glOperators.Any())
@@ -74,28 +75,28 @@ namespace OpenTKAnalyzer.OpenTK.Graphics.OpenGL
 				foreach (var op in glOperators)
 				{
 					var opName = op.ChildNodes().Skip(1).First().GetFirstToken().Text;
-					if (opName == "Begin")
+					if (opName == nameof(GL.Begin))
 					{
 						counter++;
 						if (counter > 1)
 						{
-							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), "GL.End"));
+							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), nameof(GL) + "." + nameof(GL.Begin)));
 							counter = 1;
 						}
 					}
-					else if (opName == "End")
+					else if (opName == nameof(GL.End))
 					{
 						counter--;
 						if (counter < 0)
 						{
-							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), "GL.Begin"));
+							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), nameof(GL) + "." + nameof(GL.Begin)));
 							counter = 0;
 						}
 					}
 				}
 				if (counter > 1)
 				{
-					Diagnostics.Add(Diagnostic.Create(Rule, glOperators.Last().Parent.GetLocation(), "GL.End"));
+					Diagnostics.Add(Diagnostic.Create(Rule, glOperators.Last().Parent.GetLocation(), nameof(GL) + "." + nameof(GL.End)));
 				}
 
 				base.VisitBlock(node);

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
@@ -10,7 +10,7 @@ using OpenTK.Graphics.OpenGL;
 namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	class BeginEndAnalyzer : DiagnosticAnalyzer
+	public class BeginEndAnalyzer : DiagnosticAnalyzer
 	{
 		public const string DiagnosticId = "BeginEnd";
 

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
@@ -87,6 +87,7 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 
 				// block contains GL.Begin() or GL.End()
 				var counter = 0;
+				Location prevBeginLocation = null;
 				foreach (var pair in beginEnds)
 				{
 					if (pair.OperationName == nameof(GL.Begin))
@@ -96,10 +97,11 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 						{
 							Diagnostics.Add(Diagnostic.Create(
 								descriptor: Rule,
-								location: pair.Syntax.Parent.GetLocation(),
+								location: prevBeginLocation,
 								messageArgs: nameof(GL) + "." + nameof(GL.End)));
 							counter = 1;
 						}
+						prevBeginLocation = pair.Syntax.Parent.GetLocation();
 					}
 					else if (pair.OperationName == nameof(GL.End))
 					{
@@ -118,7 +120,7 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 				{
 					Diagnostics.Add(Diagnostic.Create(
 						descriptor: Rule,
-						location: beginEnds.Last().Syntax.Parent.GetLocation(),
+						location: prevBeginLocation,
 						messageArgs: nameof(GL) + "." + nameof(GL.End)));
 				}
 

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
@@ -16,7 +16,7 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 
 		private const string Title = "GL.Begin and GL.End comformity";
 		private const string MessageFormat = "Missing {0}.";
-		private const string Description = "";
+		private const string Description = "Warm on comformity of GL.Begin and GL.End seems not good.";
 		private const string Category = nameof(OpenTKAnalyzer) + ":" + nameof(OpenTK.Graphics.OpenGL);
 
 		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/BeginEndAnalyzer.cs
@@ -39,7 +39,8 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 		{
 			// filtering
 			if (context.CodeBlock.Ancestors().OfType<UsingDirectiveSyntax>()
-				.Where(u => u.Name.NormalizeWhitespace().ToFullString() == nameof(OpenTK) + "." + nameof(OpenTK.Graphics) + "." + nameof(OpenTK.Graphics.OpenGL)).Any())
+				.Where(u => u.Name.NormalizeWhitespace().ToFullString() ==
+					nameof(OpenTK) + "." + nameof(OpenTK.Graphics) + "." + nameof(OpenTK.Graphics.OpenGL)).Any())
 			{
 				return;
 			}
@@ -80,7 +81,10 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 						counter++;
 						if (counter > 1)
 						{
-							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), nameof(GL) + "." + nameof(GL.Begin)));
+							Diagnostics.Add(Diagnostic.Create(
+								descriptor: Rule,
+								location: op.Parent.GetLocation(),
+								messageArgs: nameof(GL) + "." + nameof(GL.Begin)));
 							counter = 1;
 						}
 					}
@@ -89,14 +93,20 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 						counter--;
 						if (counter < 0)
 						{
-							Diagnostics.Add(Diagnostic.Create(Rule, op.Parent.GetLocation(), nameof(GL) + "." + nameof(GL.Begin)));
+							Diagnostics.Add(Diagnostic.Create(
+								descriptor: Rule,
+								location: op.Parent.GetLocation(),
+								messageArgs: nameof(GL) + "." + nameof(GL.Begin)));
 							counter = 0;
 						}
 					}
 				}
 				if (counter > 1)
 				{
-					Diagnostics.Add(Diagnostic.Create(Rule, glOperators.Last().Parent.GetLocation(), nameof(GL) + "." + nameof(GL.End)));
+					Diagnostics.Add(Diagnostic.Create(
+						descriptor: Rule,
+						location: glOperators.Last().Parent.GetLocation(),
+						messageArgs: nameof(GL) + "." + nameof(GL.End)));
 				}
 
 				base.VisitBlock(node);


### PR DESCRIPTION
## Valid pattern

``` csharp
GL.Begin(BeginMode.Lines);
// some codes
GL.End();
```
## Invalid pattern
### GL.Begin after GL.Begin

``` csharp
GL.Begin(BeginMode.Lines);
// some codes
GL.Begin(BeginMode.Lines); /* warning */
// anothoer codes
GL.End();
```
### GL.End after GL.End

``` csharp
GL.Begin(BeginMode.Lines);
// some codes
GL.End();
// anothoer codes
GL.End(); /* warning */
```
## Note

This does not check complex code like...

``` csharp
GL.Begin(BeginMode.Lines);
if (Foo == 1) {
    GL.Begin(BeginMode.Lines); /* this */
    GL.End();
}
Bar(); /* Perhaps contains GL.Begin or GL.End */
GL.End();
```
