### PR TITLE
Analyzer for GL.Fog param(second argument)

### DIFF
--- a/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTKAnalyzer.Test.csproj
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTKAnalyzer.Test.csproj
@@ -107,6 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="OpenTK_\Graphics_\OpenGL_\BeginEndAnalyzerTests.cs" />
+    <Compile Include="OpenTK_\Graphics_\OpenGL_\FogParamAnalyzerTests.cs" />
     <Compile Include="OpenTK_\RotationValueOpenTKMathAnalyzerTests.cs" />
     <Compile Include="OpenTK_\Graphics_\OpenGL_\PushPopAnalyzerTests.cs" />
     <Compile Include="OpenTK_\Graphics_\OpenGL_\EnableLightingAnalyzerTests.cs" />

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzerTests.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer.Test/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzerTests.cs
@@ -1,0 +1,313 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTKAnalyzer.TestHelper;
+
+namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_.Tests
+{
+	[TestClass]
+	public class FogParamAnalyzerTests : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer CSharpDiagnosticAnalyzer => new FogParamAnalyzer();
+
+		[TestMethod]
+		public void EmptyCode()
+		{
+			var test0Source = @"";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void SimpleNormalScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogParameter.FogColor, new[] { 1, 2.0f });
+		GL.Fog(FogParameter.FogIndex, 0.1f);
+		GL.Fog(FogParameter.FogCoordSrc, (int)FogMode.FragmentDepth);
+		GL.Fog(FogParameter.FogMode, (int)FogMode.Exp);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void FogParameterLessNormalScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.FogParameter;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogColor, new[] { 1, 2.0f });
+		GL.Fog(FogIndex, 0.1f);
+		GL.Fog(FogCoordSrc, (int)OpenTK.Graphics.OpenGL.FogMode.FragmentDepth);
+		GL.Fog(FogParameter.FogMode, (int)OpenTK.Graphics.OpenGL.FogMode.Exp);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void FogModeLessNormalScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.FogMode;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogParameter.FogColor, new[] { 1, 2.0f });
+		GL.Fog(FogParameter.FogIndex, 0.1f);
+		GL.Fog(FogParameter.FogCoordSrc, (int)FragmentDepth);
+		GL.Fog(FogParameter.FogMode, (int)Exp);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source);
+		}
+
+		[TestMethod]
+		public void SimpleIncorrectScenario()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogParameter.FogColor, 1);
+		GL.Fog(FogParameter.FogIndex, new[] { 1, 2 });
+		GL.Fog(FogParameter.FogCoordSrc, 1);
+		GL.Fog(FogParameter.FogCoordSrc, (int)2.0);
+		GL.Fog(FogParameter.FogCoordSrc, (int)FogMode.Exp);
+		GL.Fog(FogParameter.FogMode, 1);
+		GL.Fog(FogParameter.FogMode, (int)2.0);
+		GL.Fog(FogParameter.FogMode, (int)FogMode.FragmentDepth);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source,
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogColor requires int[], float[] in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 33) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogIndex requires int, float in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 33) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 36) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 41) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 41) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 32) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 37) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 37) }
+				});
+		}
+
+		[TestMethod]
+		public void FogParameterLessIncorrectTest()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.FogParameter;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogColor, 1);
+		GL.Fog(FogIndex, new[] { 1, 2 });
+		GL.Fog(FogCoordSrc, 1);
+		GL.Fog(FogCoordSrc, (int)2.0);
+		GL.Fog(FogCoordSrc, (int)OpenTK.Graphics.OpenGL.FogMode.Exp);
+		GL.Fog(FogParameter.FogMode, 1);
+		GL.Fog(FogParameter.FogMode, (int)2.0);
+		GL.Fog(FogParameter.FogMode, (int)OpenTK.Graphics.OpenGL.FogMode.FragmentDepth);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source,
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogColor requires int[], float[] in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 20) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogIndex requires int, float in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 20) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 23) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 28) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 28) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 32) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 37) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 37) }
+				});
+		}
+
+		[TestMethod]
+		public void FogModeLessincorrectTest()
+		{
+			var test0Source = @"using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.FogMode;
+class Class1
+{
+	void Method1()
+	{
+		GL.Fog(FogParameter.FogColor, 1);
+		GL.Fog(FogParameter.FogIndex, new[] { 1, 2 });
+		GL.Fog(FogParameter.FogCoordSrc, 1);
+		GL.Fog(FogParameter.FogCoordSrc, (int)2.0);
+		GL.Fog(FogParameter.FogCoordSrc, (int)Exp);
+		GL.Fog(FogParameter.FogMode, 1);
+		GL.Fog(FogParameter.FogMode, (int)2.0);
+		GL.Fog(FogParameter.FogMode, (int)FragmentDepth);
+	}
+}";
+
+			VerifyCSharpDiagnostic(test0Source,
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogColor requires int[], float[] in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 33) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogIndex requires int, float in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 33) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 36) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 41) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogCoordSrc requires int casted FogMode.FogCoord, FogMode.FragmentDepth in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 41) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 32) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 37) }
+				},
+				new DiagnosticResult()
+				{
+					Id = FogParamAnalyzer.DiagnosticId,
+					Message = "FogParameter.FogMode requires int casted FogMode.Linear, FogMode.Exp, FogMode.Exp2 in param(second argument).",
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 37) }
+				});
+		}
+	}
+}

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTKAnalyzer.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="OpenTK_\Graphics_\OpenGL_\BeginEndAnalyzer.cs" />
+    <Compile Include="OpenTK_\Graphics_\OpenGL_\FogParamAnalyzer.cs" />
     <Compile Include="OpenTK_\RotationValueOpenTKMathAnalyzer.cs" />
     <Compile Include="OpenTK_\Graphics_\OpenGL_\PushPopAnalyzer.cs" />
     <Compile Include="OpenTK_\Graphics_\OpenGL_\EnableLightingAnalyzer.cs" />

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzer.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using OpenTK.Graphics.OpenGL;
+
+
+namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class FogParamAnalyzer : DiagnosticAnalyzer
+	{
+		public const string DiagnosticId = "FogParam";
+
+		private const string Title = "GL.Fog param(second argument).";
+		private const string MessageFormat = "{0} requires {1} in param(second argument).";
+		private const string Description = "Error on used invalid argument on GL.Fog param(second argument).";
+		private const string Category = nameof(OpenTKAnalyzer) + ":" + nameof(OpenTK.Graphics.OpenGL);
+
+		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: DiagnosticId,
+			title: Title,
+			messageFormat: MessageFormat,
+			category: Category,
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterSemanticModelAction(Analyze);
+		}
+
+		private static async void Analyze(SemanticModelAnalysisContext context)
+		{
+			var root = await context.SemanticModel.SyntaxTree.GetRootAsync();
+			var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+
+			var fogs = invocations.Where(i => i.Expression.WithoutTrivia().ToFullString() == nameof(GL) + "." + nameof(GL.Fog));
+
+			foreach (var fogOp in fogs)
+			{
+				if (fogOp.ArgumentList.Arguments.Count == 2)
+				{
+					var firstExpression = fogOp.ArgumentList.Arguments.FirstOrDefault()?.ChildNodes()?.First();
+					if (firstExpression == null)
+					{
+						continue;
+					}
+					var firstSymbol = context.SemanticModel.GetSymbolInfo(firstExpression).Symbol;
+					if (firstSymbol?.OriginalDefinition.ContainingType?.Name != nameof(FogParameter))
+					{
+						continue;
+					}
+
+					FogParameter firstEnum;
+					if (Enum.TryParse(firstSymbol.Name, out firstEnum))
+					{
+						string[] correctTypeNames = null;
+						bool useFogMode = false;
+						switch (firstEnum)
+						{
+							// *special*
+							// FogMode > Linear, Exp, exp2 (int casted)
+							case FogParameter.FogMode:
+								correctTypeNames = new[] { nameof(FogMode.Linear), nameof(FogMode.Exp), nameof(FogMode.Exp2) };
+								useFogMode = true;
+								break;
+
+							// int, float
+							case FogParameter.FogDensity:
+							case FogParameter.FogStart:
+							case FogParameter.FogEnd:
+							case FogParameter.FogIndex:
+								correctTypeNames = new[] { "int", "float" };
+								break;
+
+							// int[], float[]
+							case FogParameter.FogColor:
+								correctTypeNames = new[] { "int[]", "float[]" };
+								break;
+
+							// *special*
+							// FogMode > FogCoord, FragmentDepth (int casted)
+							case FogParameter.FogCoordSrc:
+								correctTypeNames = new[] { nameof(FogMode.FogCoord), nameof(FogMode.FragmentDepth) };
+								useFogMode = true;
+								break;
+						}
+
+						// *special*
+						if (useFogMode)
+						{
+							var argumentExpression = fogOp.ArgumentList.Arguments.Skip(1).FirstOrDefault();
+							var castExpression = argumentExpression?.ChildNodes()?.FirstOrDefault();
+
+							Location location = castExpression.GetLocation();
+							if (castExpression.IsKind(SyntaxKind.CastExpression) && castExpression.ChildNodes().FirstOrDefault()?.ToFullString() == "int")
+							{
+								var insideExpression = argumentExpression?.ChildNodes()?.FirstOrDefault()?.ChildNodes().Last();
+								if (insideExpression == null)
+								{
+									continue;
+								}
+								location = insideExpression.GetLocation();
+								var typeInfo = context.SemanticModel.GetTypeInfo(insideExpression);
+								if (typeInfo.Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) == nameof(FogMode))
+								{
+									var elementName = insideExpression.ChildNodes().LastOrDefault()?.ToFullString();
+									if (correctTypeNames.Any(n => n == elementName))
+									{
+										continue;
+									}
+								}
+							}
+							context.ReportDiagnostic(Diagnostic.Create(
+								descriptor: Rule,
+								location: location,
+								messageArgs: new[] { nameof(FogParameter) + "." + firstSymbol.Name, "int casted " + string.Join(", ", correctTypeNames.Select(n => nameof(FogMode) + "." + n)) }));
+						}
+						else
+						{
+							var secondExpression = fogOp.ArgumentList.Arguments.Skip(1).FirstOrDefault()?.ChildNodes()?.First();
+							if (secondExpression == null)
+							{
+								continue;
+							}
+							var typeInfo = context.SemanticModel.GetTypeInfo(secondExpression);
+							var typeName = typeInfo.Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
+
+							if (correctTypeNames.Any(n => n == typeName))
+							{
+								continue;
+							}
+							context.ReportDiagnostic(Diagnostic.Create(
+								descriptor: Rule,
+								location: secondExpression.GetLocation(),
+								messageArgs: new[] { nameof(FogParameter) + "." + firstSymbol.Name, string.Join(", ", correctTypeNames) }));
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzer.cs
+++ b/src/OpenTKAnalyzer/OpenTKAnalyzer/OpenTK_/Graphics_/OpenGL_/FogParamAnalyzer.cs
@@ -112,7 +112,7 @@ namespace OpenTKAnalyzer.OpenTK_.Graphics_.OpenGL_
 								var typeInfo = context.SemanticModel.GetTypeInfo(insideExpression);
 								if (typeInfo.Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) == nameof(FogMode))
 								{
-									var elementName = insideExpression.ChildNodes().LastOrDefault()?.ToFullString();
+                                    var elementName = insideExpression.DescendantNodesAndSelf().LastOrDefault()?.ToFullString();
 									if (correctTypeNames.Any(n => n == elementName))
 									{
 										continue;


### PR DESCRIPTION
## Invalid

``` csharp
GL.Fog(FogParameter.FogColor, 1);
/* error : FogColor can accept int[] or float[] */
GL.Fog(FogParameter.FogCoordSrc, (int)FogMode.Exp);
/* error : FogCoordSrc can accept (int) FogMode.FogCoord, FogMode.FragmentDepth */
```
## Note

int variable that use value by FogMode also causes Error, even if it's correct.  
This analyzer uses Semantic Model.
